### PR TITLE
chore: update ramalama image references to 0.9.2

### DIFF
--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -1,12 +1,12 @@
 {
   "whispercpp": {
-    "default": "quay.io/ramalama/ramalama-whisper-server@sha256:72bce4bed86e7f72e41c60960dd7b1fd9b5115328f520ddcae5dbdd689376995"
+    "default": "quay.io/ramalama/ramalama-whisper-server@sha256:2eb00de33d12d79e66d92afc1d231036200914fec84f70517731bbf55cf301f2"
   },
   "llamacpp": {
-    "default": "quay.io/ramalama/ramalama-llama-server@sha256:4e56101073e0bd6f2f2e15839b64315656d0dbfc1331a3385f2ae722e13f2279",
-    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:56efc824e5b3ae6a6a11e9537ed9e2ac05f9f9fc6f2e81a55eb67b662c94fe95"
+    "default": "quay.io/ramalama/ramalama-llama-server@sha256:9e93f9d0b2636e766f4e7b820a1ee1b5bf616e773cb8712ab35fa1c3f438bd3b",
+    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:bdfd70d8ed11d71a67cf7b6dd9aad5abb993b69d11fd5ab7b2bf516b5b71e9e6"
   },
   "openvino": {
-    "default": "quay.io/ramalama/openvino@sha256:670d91cc322933cc4263606459317cd4ca3fcfb16d59a46b11dcd498c2cd7cb5"
+    "default": "quay.io/ramalama/openvino@sha256:fc315cf7100bc806b2b5ce81fae9730b6f05d43cb34a3b9750d63b24aae5f286"
   }
 }


### PR DESCRIPTION
update ramalama image references to 0.9.2
